### PR TITLE
Add missing dl dependency

### DIFF
--- a/cmake/dependencies/Linux.cmake
+++ b/cmake/dependencies/Linux.cmake
@@ -11,6 +11,7 @@ function(blue_find_dependencies_linux)
 
     target_link_libraries(Dependencies INTERFACE
             SDL2::SDL2-static
+            dl
             glm
             glad
             assimp


### PR DESCRIPTION
I get this error during linking, without `dl` added:
```
/usr/bin/ld: ../../vendor/glad/opengl/libglad.a(glad.c.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: //usr/lib64/libdl.so.2: error adding symbols: DSO missing from command line
```